### PR TITLE
Added draft feature

### DIFF
--- a/composemail.cpp
+++ b/composemail.cpp
@@ -82,11 +82,10 @@ void ComposeMail::writeMails(QString filename, QString prop) {
     QJsonObject item = mails.object();
     QJsonArray sentArray = item.value(prop).toArray();
 
-    int id;
+    int id = 1000;
     foreach (const QJsonValue & v, sentArray) {
         id = v.toObject().value("id").toInt()+1;
     }
-    qDebug() << id;
     if(filename == "draft.json" && draftId.length() > 0){
         id = draftId.toInt();
     }
@@ -106,6 +105,7 @@ void ComposeMail::writeMails(QString filename, QString prop) {
     }
     sentObj.insert("attachments", atts);
     sentObj.insert("content", sent->content_);
+
     sentArray.append(sentObj);
 
     item.insert(prop, sentArray);
@@ -113,6 +113,7 @@ void ComposeMail::writeMails(QString filename, QString prop) {
 
     QByteArray bytes = mails.toJson( QJsonDocument::Indented );
     file.close();
+    qDebug() << mails;
     if( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
     {
         QTextStream iStream( &file );
@@ -132,7 +133,7 @@ void ComposeMail::deleteDraft(QString filename, QString prop) {
     QJsonObject item = mails.object();
     QJsonArray jsonArray = item.value(prop).toArray();
     QString idToDel;
-    //qDebug() << sentArray;
+
     foreach (const QJsonValue & v, jsonArray) {
             if(idToDel == v.toObject().value("id").toString()) {
                 idToDel = v.toObject().value("id").toString();
@@ -155,7 +156,6 @@ void ComposeMail::deleteDraft(QString filename, QString prop) {
 void ComposeMail::handleSubmit()
 {
     if(to->text().length() == 0 || subject->text().length() == 0 || emailBody->document()->toPlainText().length() == 0) {
-        qDebug() << "Empty";
         msg->setStyleSheet("QLabel { color: red; }");
         msg->setText("All the fields must be filled");
     }
@@ -164,17 +164,19 @@ void ComposeMail::handleSubmit()
         to->setText("");
         subject->setText("");
         emailBody->setText("");
+        deleteDraft();
         draftId = "";
-        //deleteDraft();
+
     }
 }
 
 void ComposeMail::closeClickedDraft() {
     if(to->text().length() != 0 && subject->text().length() != 0 && emailBody->document()->toPlainText().length() != 0) {
         writeMails("draft.json", "draft");
+
     }
     to->setText("");
     subject->setText("");
     emailBody->setText("");
-            deleteDraft();
+    msg->setText("");
 }

--- a/composemail.cpp
+++ b/composemail.cpp
@@ -11,7 +11,7 @@
 #include <QJsonDocument>
 #include<string>
 #include "composemail.h"
-
+#include "mailbox.h"
 ComposeMail::ComposeMail(QWidget *parent) : QWidget(parent)
 {
     QFormLayout *form = new QFormLayout();
@@ -30,14 +30,21 @@ ComposeMail::ComposeMail(QWidget *parent) : QWidget(parent)
     submit->setMaximumSize(70,200);
     connect(submit, &QPushButton::clicked, this, &ComposeMail::handleSubmit);
 
+    QPushButton *close = new QPushButton("Close");
+    close->setMaximumSize(70,200);
+    close->setStyleSheet("QPushButton {color: red};");
+    connect(close, &QPushButton::clicked, this, &ComposeMail::closeClicked);
+    connect(close, &QPushButton::clicked, this, &ComposeMail::closeClickedDraft);
     msg = new QLabel("");
     attachments = new QLabel("");
     attachments->setTextFormat(Qt::TextFormat::MarkdownText);
 
     QHBoxLayout *btmLayout = new QHBoxLayout();
+    btmLayout->addWidget(close);
     btmLayout->addWidget(attach);
     btmLayout->addWidget(submit);
     btmLayout->addWidget(msg);
+
 
     form->addRow("<b>From:</b>", from);
     form->addRow("<b>To* :</b>", to);
@@ -63,7 +70,88 @@ void ComposeMail::handleAttach()
     }
     attachments->setText(attachmentString);
 }
+void ComposeMail::handleClose()
+{
 
+}
+void ComposeMail::writeMails(QString filename, QString prop) {
+    QFile file;
+    file.setFileName(filename);
+    file.open( QIODevice::ReadOnly | QIODevice::Text );
+    QJsonDocument mails = QJsonDocument::fromJson(file.readAll());
+    QJsonObject item = mails.object();
+    QJsonArray sentArray = item.value(prop).toArray();
+
+    int id;
+    foreach (const QJsonValue & v, sentArray) {
+        id = v.toObject().value("id").toInt()+1;
+    }
+    qDebug() << id;
+    if(filename == "draft.json" && draftId.length() > 0){
+        id = draftId.toInt();
+    }
+//    if(this->id.length() > 0)
+//        id = this->id.toInt();
+    MailCP *sent = new MailCP(QString::number(id), subject->text(), to->text(), "user@gmail.com", "02/07/2011 16:47 UTC+3", attachList, emailBody->document()->toPlainText());
+    QJsonObject sentObj;
+    sentObj.insert("id", sent->id_);
+    sentObj.insert("subject", sent->subject_);
+    sentObj.insert("to", sent->to_);
+    sentObj.insert("from", sent->from_);
+    sentObj.insert("sendDate", sent->sendDate_);
+    QJsonArray atts;
+    foreach(const auto & attachment, attachList) {
+        auto attachmentDetail = attachment.split("/");
+        atts.push_back(QJsonValue(attachmentDetail[attachmentDetail.length() - 1]));
+    }
+    sentObj.insert("attachments", atts);
+    sentObj.insert("content", sent->content_);
+    sentArray.append(sentObj);
+
+    item.insert(prop, sentArray);
+    mails.setObject(item);
+
+    QByteArray bytes = mails.toJson( QJsonDocument::Indented );
+    file.close();
+    if( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
+    {
+        QTextStream iStream( &file );
+        iStream.setEncoding(QStringConverter::Utf8);
+        iStream << bytes;
+        file.close();
+    }
+    msg->setStyleSheet("QLabel { color: green; }");
+    msg->setText("Email has been sent");
+}
+
+void ComposeMail::deleteDraft(QString filename, QString prop) {
+    QFile file;
+    file.setFileName(filename);
+    file.open( QIODevice::ReadOnly | QIODevice::Text );
+    QJsonDocument mails = QJsonDocument::fromJson(file.readAll());
+    QJsonObject item = mails.object();
+    QJsonArray jsonArray = item.value(prop).toArray();
+    QString idToDel;
+    //qDebug() << sentArray;
+    foreach (const QJsonValue & v, jsonArray) {
+            if(idToDel == v.toObject().value("id").toString()) {
+                idToDel = v.toObject().value("id").toString();
+                break;
+            }
+    }
+    jsonArray.removeAt(idToDel.toInt());
+    item.insert(prop, jsonArray);
+    mails.setObject(item);
+    QByteArray bytes = mails.toJson( QJsonDocument::Indented );
+    file.close();
+    if( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
+    {
+        QTextStream iStream( &file );
+        iStream.setEncoding(QStringConverter::Utf8);
+        iStream << bytes;
+        file.close();
+    }
+}
 void ComposeMail::handleSubmit()
 {
     if(to->text().length() == 0 || subject->text().length() == 0 || emailBody->document()->toPlainText().length() == 0) {
@@ -72,46 +160,21 @@ void ComposeMail::handleSubmit()
         msg->setText("All the fields must be filled");
     }
     else {
-        QFile file;
-        file.setFileName("sent.json");
-        file.open( QIODevice::ReadOnly | QIODevice::Text );
-        QJsonDocument mails = QJsonDocument::fromJson(file.readAll());
-        QJsonObject item = mails.object();
-        QJsonArray sentArray = item.value("sent").toArray();
-
-        int id = 1000;
-        foreach (const QJsonValue & v, sentArray) {
-            id++;
-        }
-        Sent *sent = new Sent(QString::number(id), subject->text(), to->text(), "user@gmail.com", "02/07/2011 16:47 UTC+3", attachList, emailBody->document()->toPlainText());
-        QJsonObject sentObj;
-        sentObj.insert("id", sent->id_);
-        sentObj.insert("subject", sent->subject_);
-        sentObj.insert("to", sent->to_);
-        sentObj.insert("from", sent->from_);
-        sentObj.insert("sendDate", sent->sendDate_);
-        QJsonArray atts;
-        foreach(const auto & attachment, attachList) {
-            auto attachmentDetail = attachment.split("/");
-            atts.push_back(QJsonValue(attachmentDetail[attachmentDetail.length() - 1]));
-        }
-        sentObj.insert("attachments", atts);
-        sentObj.insert("content", sent->content_);
-        sentArray.append(sentObj);
-
-        item.insert("sent", sentArray);
-        mails.setObject(item);
-
-        QByteArray bytes = mails.toJson( QJsonDocument::Indented );
-        file.close();
-        if( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
-        {
-            QTextStream iStream( &file );
-            iStream.setEncoding(QStringConverter::Utf8);
-            iStream << bytes;
-            file.close();
-        }
-        msg->setStyleSheet("QLabel { color: green; }");
-        msg->setText("Email has been sent");
+        writeMails("sent.json", "sent");
+        to->setText("");
+        subject->setText("");
+        emailBody->setText("");
+        draftId = "";
+        //deleteDraft();
     }
+}
+
+void ComposeMail::closeClickedDraft() {
+    if(to->text().length() != 0 && subject->text().length() != 0 && emailBody->document()->toPlainText().length() != 0) {
+        writeMails("draft.json", "draft");
+    }
+    to->setText("");
+    subject->setText("");
+    emailBody->setText("");
+            deleteDraft();
 }

--- a/composemail.h
+++ b/composemail.h
@@ -7,10 +7,12 @@
 #include <QLabel>
 #include <QTextEdit>
 
+//#include "mailbox.h"
 class ComposeMail : public QWidget
 {
     Q_OBJECT
-    struct Sent {
+
+    struct MailCP {
         QString id_;
         QString subject_;
         QString to_;
@@ -18,7 +20,10 @@ class ComposeMail : public QWidget
         QString sendDate_;
         QString content_;
         QList<QString> attachments_;
-        Sent(QString id, QString subject, QString to, QString from, QString sendDate, QList<QString> attachments, QString content) {
+        MailCP() {
+
+        }
+        MailCP(QString id, QString subject, QString to, QString from, QString sendDate, QList<QString> attachments, QString content) {
             to_ = to;
             subject_ = subject;
             content_ = content;
@@ -28,21 +33,33 @@ class ComposeMail : public QWidget
             id_ = id;
         }
     };
-
 public:
+
+    MailCP mailcp;
+
+    QString draftId;
+
+    //QString id;
     QLineEdit *to;
     QLineEdit *subject;
     QTextEdit *emailBody;
     QLabel *attachments;
     QLabel *msg;
 
+    void writeMails(QString filename, QString prop);
+
     QList<QString> attachList;
 
     explicit ComposeMail(QWidget *parent = nullptr);
-
+    void deleteDraft(QString filename = "draft.json", QString prop = "draft");
 private slots:
     void handleSubmit();
     void handleAttach();
+    void handleClose();
+    void closeClickedDraft();
+signals:
+    void closeClicked();
+    void submitted();
 };
 
 #endif // COMPOSEMAIL_H

--- a/composemail.h
+++ b/composemail.h
@@ -59,7 +59,6 @@ private slots:
     void closeClickedDraft();
 signals:
     void closeClicked();
-    void submitted();
 };
 
 #endif // COMPOSEMAIL_H

--- a/draft.json
+++ b/draft.json
@@ -1,0 +1,24 @@
+{
+    "draft": [
+        {
+            "attachments": [
+            ],
+            "content": "asdzzxcasd",
+            "from": "user@gmail.com",
+            "id": "1000",
+            "sendDate": "02/07/2011 16:47 UTC+3",
+            "subject": "aaaa",
+            "to": "123"
+        },
+        {
+            "attachments": [
+            ],
+            "content": "aazzxcv",
+            "from": "user@gmail.com",
+            "id": "1001",
+            "sendDate": "02/07/2011 16:47 UTC+3",
+            "subject": "asd",
+            "to": "asd"
+        }
+    ]
+}

--- a/mail.cpp
+++ b/mail.cpp
@@ -21,7 +21,6 @@ Mail::Mail(QString id, QString subject, QString to, QString from, QString sendDa
     this->receiveDate = receiveDate;
     this->attachments = attachments;
     this->content = content;
-
     QVBoxLayout *mailLayout = new QVBoxLayout();
 
     QLabel* fromLabel = new QLabel("<b>" + this->from + "</b>");
@@ -37,6 +36,7 @@ Mail::Mail(QString id, QString subject, QString to, QString from, QString sendDa
     mailLayout->addWidget(contentLabel);
 
     setLayout(mailLayout);
+
 }
 
 void Mail::mousePressEvent(QMouseEvent *event)

--- a/mail.pro
+++ b/mail.pro
@@ -1,0 +1,34 @@
+QT       += core gui
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+CONFIG += c++11
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+    composemail.cpp \
+    mail.cpp \
+    mailbox.cpp \
+    maildetails.cpp \
+    main.cpp
+
+HEADERS += \
+    composemail.h \
+    mail.h \
+    mailbox.h \
+    maildetails.h
+
+FORMS +=
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+DISTFILES += \
+    draft.json \
+    mails.json \
+    sent.json

--- a/mailbox.cpp
+++ b/mailbox.cpp
@@ -122,6 +122,7 @@ void MailBox::onComposeClicked()
     for(int i = 0; i < topBtns.size(); i++) {
         topBtns[i]->blockSignals(true);
     }
+    composeBox->draftId = "";
     composeBox->show();
 
 }

--- a/mailbox.cpp
+++ b/mailbox.cpp
@@ -132,7 +132,7 @@ void MailBox::readMails(bool draft) {
     file.open(QIODevice::ReadWrite | QIODevice::Text);
     QJsonDocument mails = QJsonDocument::fromJson(file.readAll());
     QJsonObject item = mails.object();
-
+qDebug() << item;
     wdg = new QWidget;
     QScrollArea *scroll = new QScrollArea;
     QWidget *content_widget = new QWidget;
@@ -189,17 +189,17 @@ void MailBox::readMails(bool draft) {
 }
 
 void MailBox::onDeleteClicked() {
-    QString selected = box == "inbox" ? selectedMail : selectedDraft;
-    if(box == "inbox" || box == "draft") {
+    QString selected = box == "draft" ? selectedDraft : selectedMail;
+
         for(auto it = messages.begin(); it != messages.end(); it++) {
-            if((*it).toObject().value("id")==selectedMail) {
+            if((*it).toObject().value("id")==selected) {
                 messages.erase(it);
                 writeMails();
-                readMails();
+                readMails(box == "draft" ? true : false);
                 mail->clearDetails();
                 break;
             }
-        }
+
     }
 }
 
@@ -209,6 +209,8 @@ void MailBox::writeMails() {
     file.open(QIODevice::ReadWrite | QIODevice::Truncate |QIODevice::Text);
 
     QString prop = currentInbox == "mails.json" ? "messages" : "sent";
+    if(currentInbox == "draft.json")
+        prop = "draft";
     QJsonObject mails;
     QJsonArray propArr(messages);
     mails.insert(prop, propArr);
@@ -220,7 +222,7 @@ void MailBox::writeMails() {
 
 void MailBox::onSentClicked()
 {
-    qDebug() << "Yo";
+    box = "sent";
     currentInbox="sent.json";
     mail->clearDetails();
     readMails();
@@ -242,6 +244,8 @@ void MailBox::onCloseCompose() {
     for(int i = 0; i < topBtns.size(); i++) {
         topBtns[i]->blockSignals(false);
     }
+    onInboxClicked();
+
 }
 void MailBox::onDraftClicked() {
     box = "draft";

--- a/mailbox.h
+++ b/mailbox.h
@@ -8,6 +8,8 @@
 #include <QGridLayout>
 #include <QList>
 #include <QLabel>
+#include <QPushButton>
+#include <QVector>
 
 #include "mail.h"
 #include "maildetails.h"
@@ -17,6 +19,8 @@ class MailBox : public QWidget
     Q_OBJECT
 
 private:
+    QString box;
+
     QJsonArray messages;
     MailDetails *mail;
     QGridLayout *mainlayout;
@@ -24,9 +28,17 @@ private:
     ComposeMail *composeBox;
 
     QString selectedMail;
+    QString selectedDraft;
     QString currentInbox;
 
-    void readMails();
+    QVector<QPushButton*> topBtns;
+
+    Mail** m2;
+    int msgLength;
+
+    QWidget *wdg;
+
+    void readMails(bool draft = false);
     void writeMails();
 public:
     MailBox(QWidget *parent = nullptr);
@@ -38,5 +50,8 @@ private slots:
     void onSentClicked();
     void onInboxClicked();
     void onDeleteClicked();
+    void onCloseCompose();
+    void onDraftClicked();
+    void onDraftSelect(QString id);
 };
 #endif // MAILBOX_H


### PR DESCRIPTION
When compose window is up, all buttons except `close`, `attach`, `send` don't receive signals. Only `send` or `close` will close compose window
![image](https://user-images.githubusercontent.com/58532267/143942067-6d4cb0f6-86a0-4c61-9f6e-5e623fc87400.png)

Clicking `close` will save unsent mail to `draft.json`
![image](https://user-images.githubusercontent.com/58532267/143942405-0aa91415-67d7-44d7-b848-102a82c35968.png)
![image](https://user-images.githubusercontent.com/58532267/143942425-47c9fec9-b58b-497c-96c9-e363a41bc990.png)

Clicking `draft` button, clicking on a draft, a compose window will appear. 
![image](https://user-images.githubusercontent.com/58532267/143942859-02a9d30b-533a-44cb-9cd7-697fbc48f1ab.png)


**Bugs:**
- Draft window doesn't refresh properly 
- Doesn't display attachment from `draft.json` in compose window when click on a draft